### PR TITLE
Make test.cpp more protable

### DIFF
--- a/source/install.rst
+++ b/source/install.rst
@@ -126,7 +126,7 @@ Let us consider the same example as before for Python. Here, we want to compile 
     using namespace std;
 
     int main(){
-        auto A = zeros(4);
+        auto A = cytnx::zeros(4);
         cout << A << endl;        
         return 0;
     }


### PR DESCRIPTION
While compiling test.cpp, I encountered the following error:

    test.cpp: In function ‘int main()’:
    test.cpp:10:14: error: ‘zeros’ was not declared in this scope; did you mean ‘cytnx::zeros’?

Some modern compilers or compiler options may resolve this automatically. However, explicitly declaring it improves clarity and lowers the entry barrier for beginners.